### PR TITLE
Now finds the Numpy headers itself, no end-user intervention required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
+import numpy as np 
 
 VERSION = '1.0.2'
 
@@ -10,6 +11,7 @@ ext_modules = [
                   "pycodec2/codec2.pxd",
                   "pycodec2/pycodec2.pyx",
               ],
+              include_dirs=[np.get_include()],
               libraries=["codec2"]) # Unix-like specific
 ]
 


### PR DESCRIPTION
Pycodec2, it is a vital component in the data augmentation for PASE+, which I love, and so by extension, I love pycodec2!  However, the install process could be easier - by default, it falls over, unable to find the numpy headers.  Of course this can be fixed by amending CFLAGS, but with this change, this is now done auto-magically.