### PR TITLE
Update for recently added Codec2 modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,7 @@ Remarks
 Codec2 assumes that input files: use 8kHz bitrate, 16-bit width samples, and a
 single channel.
 
+Look for `_modes` in `pycodec2/pycodec2.pyx` for a list of currently supported modes.
+
 This library is considered complete. Please notify me or send a pull request on
 Github if you notice any bugs.

--- a/pycodec2/codec2.pxd
+++ b/pycodec2/codec2.pxd
@@ -6,7 +6,9 @@ cdef extern from 'codec2/codec2.h':
     CODEC2_MODE_1400 = 3
     CODEC2_MODE_1300 = 4
     CODEC2_MODE_1200 = 5
-
+    CODEC2_MODE_700C = 8
+    CODEC2_MODE_450  = 10
+    CODEC2_MODE_450PWB  = 11
   cdef struct CODEC2:
     pass
 

--- a/pycodec2/pycodec2.pyx
+++ b/pycodec2/pycodec2.pyx
@@ -9,7 +9,7 @@ ctypedef cnp.int_t INT_DTYPE_t
 
 _modes = {
     450  : CODEC2_MODE_450,
-    451  : CODEC2_MODE_450PWB, #Decode only! Encode with 450, decode with 451 to use
+    451  : CODEC2_MODE_450PWB, 
     700  : CODEC2_MODE_700C,
     1200 : CODEC2_MODE_1200,
     1300 : CODEC2_MODE_1300,

--- a/pycodec2/pycodec2.pyx
+++ b/pycodec2/pycodec2.pyx
@@ -4,11 +4,13 @@ import math
 
 import numpy as np
 cimport numpy as cnp
-
 ctypedef cnp.int16_t SHORT_DTYPE_t
 ctypedef cnp.int_t INT_DTYPE_t
 
 _modes = {
+    450  : CODEC2_MODE_450,
+    451  : CODEC2_MODE_450PWB, #Decode only! Encode with 450, decode with 451 to use
+    700  : CODEC2_MODE_700C,
     1200 : CODEC2_MODE_1200,
     1300 : CODEC2_MODE_1300,
     1400 : CODEC2_MODE_1400,


### PR DESCRIPTION
Adds the 700C and 450 bit/s modes.
Also adds a tiny blurb to the README to make it more obvious where to find the list of modes.

Thanks for this wrapper, very convenient! 