### PR TITLE
Add support for MacOS Arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           cd build_linux &&
           cmake .. &&
           make &&
-          make install
+          sudo make install
           # brew update
           # brew install codec2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         # Supported runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         # Not supporting Windows, because there's no codec2 package for Windows' package manager.
-        os: [ubuntu-22.04, macOS-13]
+        os: [ubuntu-22.04, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
         run: python -m pip install cibuildwheel==2.16.2
 
       - name: Install codec2 on macOS
-        if: matrix.os == 'macOS-13'
+        if: contains(matrix.os, 'macos')
         run: |
           git clone https://github.com/drowe67/codec2 &&
           cd codec2 &&

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include pycodec2/pycodec2.c
+include pycodec2/pycodec2.pyx
+include pycodec2/codec2.pxd

--- a/pycodec2/pycodec2.pyx
+++ b/pycodec2/pycodec2.pyx
@@ -11,6 +11,8 @@ ctypedef cnp.int8_t CHAR_DTYPE_t
 ctypedef cnp.int16_t SHORT_DTYPE_t
 ctypedef cnp.int_t INT_DTYPE_t
 
+cnp.import_array()
+
 _modes = {
     700  : CODEC2_MODE_700C,
     1200 : CODEC2_MODE_1200,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ requires-python = ">=3.9"
 # Use-time dependencies.
 dependencies = [
   # The package will error out on import if these are not installed.
-  "numpy>=1.22",
+  "numpy>=1.22, <2.0.0",
 ]


### PR DESCRIPTION
Fix for issue #37

1. Add github action build for MacOS Arm64
2. Fix an issue where sdist was missing files and failed pip install
3. Added missing `sudo` in build script
4. Added missing numpy `import_array()` call 
5. Cap numpy versions at 1.x due to ABI issues