### PR TITLE
Enable windows support with linux cross-compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [workflow_dispatch, push]
+on: workflow_dispatch
 env:
   # Codec2 is required for the build process, so instruct cibuildwheel to
   # install the currently supported version.
@@ -12,11 +12,11 @@ env:
     cmake .. &&
     make &&
     make install
-
+  # Don't support x86, because I had problems getting a successful build.
   CIBW_ARCHS_LINUX: x86_64
   # A smoke test for each wheel.
   CIBW_TEST_COMMAND: >
-    python -c "import sys;print(sys.path);import pycodec2"
+    python -c "import pycodec2"
 jobs:
   build_sdist:
     name: Build sdist
@@ -131,13 +131,8 @@ jobs:
   build_wheels_windows:
     needs:
       - cross_compile_windows
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # Supported runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        os: [windows-latest]
-
+    name: Build wheels on windows-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: workflow_dispatch
+on: [workflow_dispatch, push]
 env:
   # Codec2 is required for the build process, so instruct cibuildwheel to
   # install the currently supported version.
@@ -12,11 +12,11 @@ env:
     cmake .. &&
     make &&
     make install
-  # Don't support x86, because I had problems getting a successful build.
+
   CIBW_ARCHS_LINUX: x86_64
   # A smoke test for each wheel.
   CIBW_TEST_COMMAND: >
-    python -c 'import pycodec2'
+    python -c "import sys;print(sys.path);import pycodec2"
 jobs:
   build_sdist:
     name: Build sdist
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         # Supported runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        # Not supporting Windows, because there's no codec2 package for Windows' package manager.
+        # Not supporting Windows, because there's no codec2 package for Windows' package manager.Use cross compilation to support windows
         os: [ubuntu-24.04, macos-13, macos-14]
 
     steps:
@@ -78,11 +78,111 @@ jobs:
           name: pycodec2-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
+  cross_compile_windows:
+    name: cross compile windows on ubuntu
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: build_linux
+        run: |
+          git clone https://github.com/drowe67/codec2 &&
+          cd codec2 &&
+          git checkout 1.2.0 &&
+          mkdir build_linux &&
+          cd build_linux &&
+          cmake .. &&
+          make &&
+          sudo make install
+      
+      - name: build_windows
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y mingw-w64 &&
+          cd codec2 &&
+          mkdir build_windows &&
+          echo "set(CMAKE_SYSTEM_NAME Windows)" > Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_C_COMPILER \${TOOLCHAIN_PREFIX}-gcc)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_CXX_COMPILER \${TOOLCHAIN_PREFIX}-g++)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_RC_COMPILER \${TOOLCHAIN_PREFIX}-windres)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_FIND_ROOT_PATH /usr/\${TOOLCHAIN_PREFIX})" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_C_FLAGS \"\${CMAKE_C_FLAGS} -m64\")" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_CXX_FLAGS \"\${CMAKE_CXX_FLAGS} -m64\")" >> Toolchain-Ubuntu-mingw32.cmake &&
+          echo "set(CMAKE_SIZEOF_VOID_P 8)" >> Toolchain-Ubuntu-mingw32.cmake &&
+          cd build_windows &&
+          cmake -DCMAKE_TOOLCHAIN_FILE=../Toolchain-Ubuntu-mingw32.cmake -DUNITTEST=FALSE -DGENERATE_CODEBOOK=../build_linux/src/generate_codebook -DCMAKE_BUILD_TYPE=Release .. &&
+          make
+
+      - name: Upload libs for windows
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-libs
+          path: |
+            codec2/build_windows/src/libcodec2.dll
+            codec2/build_windows/src/libcodec2.dll.a
+            codec2/build_windows/codec2/version.h
+            codec2/src/codec2.h
+            /usr/lib/gcc/x86_64-w64-mingw32/13-win32/libgcc_s_seh-1.dll
+  
+  build_wheels_windows:
+    needs:
+      - cross_compile_windows
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Supported runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Used to host cibuildwheel
+      # https://github.com/actions/setup-python
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.22.0
+
+      - name: Download libs for windows
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-libs
+          path: temp/
+          pattern: true
+
+      - name: Copy libs for windows
+        run: |
+          mkdir lib_win &&
+          mkdir pycodec2/codec2 &&
+          cp .\temp\home\runner\work\pycodec2\pycodec2\codec2\build_windows\src\libcodec2.dll lib_win\libcodec2.dll &&
+          cp .\temp\home\runner\work\pycodec2\pycodec2\codec2\build_windows\src\libcodec2.dll.a lib_win\libcodec2.lib &&
+          cp .\temp\home\runner\work\pycodec2\pycodec2\codec2\build_windows\codec2\version.h pycodec2\codec2\version.h &&
+          cp .\temp\home\runner\work\pycodec2\pycodec2\codec2\src\codec2.h pycodec2\codec2\codec2.h &&
+          cp .\temp\usr\lib\gcc\x86_64-w64-mingw32\13-win32\libgcc_s_seh-1.dll lib_win\libgcc_s_seh-1.dll &&
+          ls lib_win
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse --archs AMD64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pycodec2-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+  
+
   merge:
     runs-on: ubuntu-latest
     needs:
       - build_sdist
       - build_wheels
+      - build_wheels_windows
     steps:
       - name: Merge artifacts
         uses: actions/upload-artifact/merge@v4

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import Cython.Build
 from Cython.Build import cythonize
 from setuptools import Extension, setup
 import numpy as np
+import sys
 
 # Extension API reference:
 # https://setuptools.pypa.io/en/latest/userguide/ext_modules.html.
@@ -21,14 +22,22 @@ ext_modules = [
         # Not including this line, will cause an error upon using pycodec2:
         # > ImportError: dlopen(/Users/grzesiek/Code/pycodec2-202310/build/lib.macosx-13.3-arm64-cpython-311/pycodec2.cpython-311-darwin.so, 0x0002):
         # > symbol not found in flat namespace '_codec2_700c_eq'
-        libraries=["codec2"])
+        library_dirs=["lib_win"] if sys.platform == "win32" else None,
+        libraries=["libcodec2"] if sys.platform == "win32" else ["codec2"],
+        # extra_link_args=["/VERBOSE"], # only works with MSVC
+    )
 ]
 
 setup(
-    packages=['pycodec2'],
+    packages=["pycodec2"],
     ext_modules=cythonize(ext_modules),
-    author='Grzegorz Milka',
-    author_email='grzegorzmilka@gmail.com',
-    url='https://github.com/gregorias/pycodec2',
-    cmdclass={'build_ext': Cython.Build.build_ext},
+    author="Grzegorz Milka",
+    author_email="grzegorzmilka@gmail.com",
+    url="https://github.com/gregorias/pycodec2",
+    cmdclass={"build_ext": Cython.Build.build_ext},
+    data_files=(
+        [("Lib/site-packages/pycodec2", ["lib_win/libcodec2.dll", "lib_win/libgcc_s_seh-1.dll"])]
+        if sys.platform == "win32"
+        else None
+    ),
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ ext_modules = [
         # > symbol not found in flat namespace '_codec2_700c_eq'
         library_dirs=["lib_win"] if sys.platform == "win32" else None,
         libraries=["libcodec2"] if sys.platform == "win32" else ["codec2"],
-        # extra_link_args=["/VERBOSE"], # only works with MSVC
     )
 ]
 


### PR DESCRIPTION
Some of the changes are for test use.
Two procedures were added：
1. Use cross compilation in ubuntu24 to obtain the AMD64 architecture DLL and LIB
2. Move to windows to compile pycodec2 using MSVC

Because try to link DLL directly in windows, setup.py needs to use a different strategy depending on the platform information